### PR TITLE
fix compile error

### DIFF
--- a/x86_64/include/lapic.h
+++ b/x86_64/include/lapic.h
@@ -84,7 +84,7 @@ void
 enable_local_apic(void);
 
 
-inline uint32_t
+extern uint32_t
 cpu(void);
 
 void


### PR DESCRIPTION
$ KVM='--enable-kvm --cpu host' ZELDA64=. CC=gcc make run
[Cleaning] kernel
[Cleaning] bootloader
[Cleaning] guest64
[AS] entry.S
[AS] init32.S
[AS] interrupt_service_routine.S
[CC] lib.c
[CC] trivial_paging.c
[CC] video.c
[CC] printk.c
[CC] gdt64.c
[CC] init.c
[CC] interrupt.c
[CC] tetris.c
[CC] serial.c
[CC] portio.c
[CC] pit.c
[CC] keyboard.c
[CC] timer.c
[LD] guest64.elf
[CT] guest64.img
[CC] init/lapic_timer.c
In file included from init/lapic_timer.c:6:
./x86_64/include/lapic.h:88:1: error: inline function ‘cpu’ declared but never defined [-Werror]
 cpu(void);
 ^~~
cc1: all warnings being treated as errors
make: *** [mk/kernel64.mk:27: init/lapic_timer.o] Error 1